### PR TITLE
Fix header names in _reader.py

### DIFF
--- a/src/in_silico_fate_mapping/_reader.py
+++ b/src/in_silico_fate_mapping/_reader.py
@@ -7,7 +7,7 @@ TRACKS_HEADER = (
     ("track_id", "TrackID"),
     ("t", "T"),
     ("z", "Z"),
-    ("y", "Z"),
+    ("y", "Y"),
     ("x", "X"),
 )
 


### PR DESCRIPTION
This is a tiny fix for the header of the y/Y column.